### PR TITLE
Generalization of udev rule and streamlined script approach

### DIFF
--- a/99-olkb-planck.rules
+++ b/99-olkb-planck.rules
@@ -1,1 +1,1 @@
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="feed", ATTRS{idProduct}=="6060", RUN+="/home/james/code/pollkb.sh"
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="feed", ATTRS{idProduct}=="6060", RUN+="pollkb.sh '%p'"

--- a/README.md
+++ b/README.md
@@ -2,8 +2,21 @@
 
 This is a udev rule and a bash script that will wake up your keyboard so you can use it after plugging it in, without having to either reboot or `cat /dev/hidraw`.
 
-Put the udev rule in /etc/udev/rules.d/ 
+Put the udev rule in `/etc/udev/rules.d/`.
 
-Make sure you either put pollkb.sh in `~/code/wakeUp/` or if you prefer another location edit the udev rule to match the location you prefer.
+Make sure you either put `pollkb.sh` in `/usr/lib/udev/`, or, if you prefer another location, edit the udev rule to match the location you prefer.
 
-Check that permissions for `99-olkb-plank.rules` are correct. If they are not, they can be correctly set with ```chmod 644 /etc/udev/rules.d/99-olkb-planck.rules```
+Check that permissions for `99-olkb-plank.rules` and `pollkb.sh` are correct. If they are not, they can be correctly set with
+
+```
+chmod 0644 /etc/udev/rules.d/99-olkb-planck.rules
+chmod 0755 /usr/lib/udev/pollkb.sh
+```
+
+To install the script and udev rule automatically in the recommended locations
+with correct permissions, you may run the enclosed `install.sh` script with
+root permissions:
+
+```
+sudo bash -c ./install.sh
+```

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# remove eventually existing files
+rm -f /etc/udev/rules.d/99-olkb-planck.rules /usr/lib/udev/pollkb.sh
+
+# install udev rule and script to expected locations with proper permissions
+install -D -m0644 -o0 -g0 99-olkb-planck.rules /etc/udev/rules.d/
+install -D -m0755 -o0 -g0 pollkb.sh /usr/lib/udev/


### PR DESCRIPTION
I adapted the rule and script to require less manual intervention by a user who likely doesn't have any clue about `udev` whatsoever, and just wants some magic script to run to have their keyboard work properly. An enclosed installation script takes care of placing everything consistently.

The script itself also tries to be more clever, and uses reliable information from udev in form of the supplied devpath argument, to determine the correct hidraw device, instead of messily finagling info out of dmesg. It also prevents multiple cats on the same device now, and is less complex overall.
However, the side-effect of *not* running multiple times may have adverse effects on the actual workaround and/or timing that made it work before, and I cannot test this for realsies due to not owning an affected keyboard model. :P